### PR TITLE
Shortened O' Saluvan text string

### DIFF
--- a/strings.yaml
+++ b/strings.yaml
@@ -2716,7 +2716,7 @@ Gクラッシャー:
 "オサルバン":
   english: "O'Saluvan"
 "ひとだのみ":
-  english: "Counting on others"
+  english: "Relies on others"
 "公衆電話<こうしゅうでんわ>で話<はな>し中<ちゅう>のところを発見<はっけん>されゲッチュされる。":
   english: "Caught while talking in a phone\nbooth."
 " じきに仲間<なかま>が助<たす>けにくるぞ!\n きっと来<く>る! たぶん来<く>る!":


### PR DESCRIPTION
The original description text "counting on others" was too long with the name so both lines of text appeared close together. Shortening it to "relies" instead should fix this problem.